### PR TITLE
Replace the travis build badge in the Readme with one from the workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/patroklossam/WareHouse.svg?branch=master)](https://travis-ci.org/patroklossam/WareHouse)
+![Build Status](https://github.com/patroklossam/WareHouse/actions/workflows/build.yml/badge.svg)
 [![codecov](https://codecov.io/gh/patroklossam/WareHouse/branch/master/graph/badge.svg)](https://codecov.io/gh/patroklossam/WareHouse)
 
 # WareHouse


### PR DESCRIPTION
Replace the travis build badge in the Readme with one from the workflow

Fixes #80
Docs with examples of how to add a workflow status badge: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge